### PR TITLE
feat: poc implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,96 @@ A collection of react-internal hooks and utils.
 ![](.github/itsfine.png)
 
 This a growing exploration of `React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`. As such you will be able to betray Reacts component abstraction, like injecting a context, or accessing the nearest parent of your component. I'm sure you want me to tell you how safe and stable this all is.
+
+### useFiber
+
+Returns the current react-internal `Fiber`.
+
+```tsx
+function Component() {
+  const fiber = useFiber()
+
+  React.useLayoutEffect(() => {
+    console.log(fiber.type) // function Component
+  }, [fiber])
+}
+```
+
+### useContainer
+
+Returns the current react-reconciler `Container`.
+
+```tsx
+function Component() {
+  const container = useContainer()
+
+  React.useLayoutEffect(() => {
+    console.log(container.containerInfo.getState()) // Zustand store (e.g. R3F)
+  }, [container])
+}
+```
+
+### useNearestChild
+
+Returns the nearest react-reconciler child instance.
+
+```tsx
+function Component() {
+  const childRef = useNearestChild()
+
+  React.useLayoutEffect(() => {
+    console.log(childRef.current) // { type: 'primitive', props: {}, children: [] } (e.g. react-nil)
+  }, [])
+
+  return <primitive />
+}
+```
+
+### useNearestParent
+
+Returns the nearest react-reconciler parent instance.
+
+```tsx
+function Component() {
+  const parentRef = useNearestParent()
+
+  React.useLayoutEffect(() => {
+    console.log(parentRef.current) // { type: 'primitive', props: {}, children: [] } (e.g. react-nil)
+  }, [])
+
+  return null
+}
+
+export default () => (
+  <primitive>
+    <Component />
+  </primitive>
+)
+```
+
+### useContextBridge
+
+Returns a `ContextBridge` of live context providers to pierce context across renderers.
+
+```tsx
+function Canvas(props: { children: React.ReactNode }) {
+  const Bridge = useContextBridge()
+  render(<Bridge>{props.children}</Bridge>)
+  return null
+}
+
+ReactDOM.createRoot(window.root).render(
+  <Providers>
+    <Canvas />
+  </Providers>,
+)
+```
+
+### traverseFiber
+
+Traverses through a `Fiber`, return `true` to halt.
+
+```ts
+const ascending = true
+const prevElement = traverseFiber(fiber, ascending, (node) => node.type === 'element')
+```

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^18.7.14",
     "@types/react": "^18.0.17",
     "react": "^18.2.0",
-    "react-nil": "^1.0.0",
+    "react-nil": "^1.1.0",
     "rimraf": "^3.0.2",
     "suspend-react": "^0.0.8",
     "typescript": "^4.7.4",

--- a/package.json
+++ b/package.json
@@ -32,13 +32,15 @@
   "devDependencies": {
     "@types/node": "^18.7.14",
     "@types/react": "^18.0.17",
+    "@types/react-test-renderer": "^18.0.0",
     "react": "^18.2.0",
     "react-nil": "^1.1.0",
+    "react-test-renderer": "^18.2.0",
     "rimraf": "^3.0.2",
     "suspend-react": "^0.0.8",
     "typescript": "^4.7.4",
     "vite": "^3.0.9",
-    "vitest": "^0.22.1"
+    "vitest": "^0.23.0"
   },
   "dependencies": {
     "@types/react-reconciler": "^0.28.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,25 +60,18 @@ export function useFiber(): Fiber {
 }
 
 /**
- * Represents a reconciler container.
- */
-export interface Container<T = {}> {
-  containerInfo: T
-}
-
-/**
  * Returns the nearest reconciler {@link Container}.
  */
-export function useNearestContainer<T = any>(): React.MutableRefObject<Container<T> | undefined> {
+export function useNearestContainer<T = any>(): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()
-  const container = React.useRef<Container<T>>(null!)
+  const container = React.useRef<T>(null!)
 
   React.useLayoutEffect(() => {
     container.current = __unsafe_traverse_fiber(
       fiber,
       (node) => node.stateNode != null && node.stateNode.containerInfo != null,
       true,
-    )?.stateNode
+    )?.stateNode.containerInfo
   }, [fiber])
 
   return container

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export function useFiber(): Fiber {
 }
 
 /**
- * Returns the nearest reconciler {@link Container}.
+ * Returns the nearest react-reconciler {@link Container}.
  */
 export function useNearestContainer<T = any>(): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()
@@ -78,7 +78,7 @@ export function useNearestContainer<T = any>(): React.MutableRefObject<T | undef
 }
 
 /**
- * Returns the nearest reconciler instance. Pass `true` to `ascending` to search upwards.
+ * Returns the nearest react-reconciler instance. Pass `true` to `ascending` to search upwards.
  */
 export function useNearestInstance<T = any>(ascending: boolean = false): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export type FiberSelector = (node: Fiber) => boolean | void
 /**
  * Traverses through a {@link Fiber}, return `true` to halt. `ascending` is `false` by default.
  */
-export function __unsafe_traverse_fiber(fiber: Fiber, selector: FiberSelector, ascending = false): Fiber | undefined {
+export function traverseFiber(fiber: Fiber, selector: FiberSelector, ascending = false): Fiber | undefined {
   let halted = false
   let selected: Fiber | undefined
 
@@ -73,8 +73,7 @@ export function useContainer<T = any>(): Container<T> {
   const fiber = useFiber()
   const container = React.useMemo(
     () =>
-      __unsafe_traverse_fiber(fiber, (node) => node.stateNode != null && node.stateNode.containerInfo != null, true)!
-        .stateNode,
+      traverseFiber(fiber, (node) => node.stateNode != null && node.stateNode.containerInfo != null, true)!.stateNode,
     [fiber],
   )
 
@@ -89,7 +88,7 @@ export function useNearestInstance<T = any>(ascending: boolean = false): React.M
   const instance = React.useRef<T>()
 
   React.useLayoutEffect(() => {
-    instance.current = __unsafe_traverse_fiber(fiber, (node) => typeof node.type === 'string', ascending)?.stateNode
+    instance.current = traverseFiber(fiber, (node) => typeof node.type === 'string', ascending)?.stateNode
   }, [fiber, ascending])
 
   return instance

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export interface Container<T = {}> {
 }
 
 /**
- * Returns the nearest reconciler container.
+ * Returns the nearest reconciler {@link Container}.
  */
 export function useNearestContainer<T = any>(): React.MutableRefObject<Container<T> | undefined> {
   const fiber = useFiber()

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export interface Container<T = {}> {
 /**
  * Returns the nearest reconciler container.
  */
-export function useContainer<T = any>(): React.MutableRefObject<Container<T>> {
+export function useNearestContainer<T = any>(): React.MutableRefObject<Container<T> | undefined> {
   const fiber = useFiber()
   const container = React.useRef<Container<T>>(null!)
 
@@ -77,7 +77,7 @@ export function useContainer<T = any>(): React.MutableRefObject<Container<T>> {
     container.current = __unsafe_traverse_fiber(
       fiber,
       (node) => node.stateNode != null && node.stateNode.containerInfo != null,
-    )!.stateNode
+    )?.stateNode
   }, [fiber])
 
   return container
@@ -86,7 +86,7 @@ export function useContainer<T = any>(): React.MutableRefObject<Container<T>> {
 /**
  * Returns the nearest {@link Fiber} instance. Pass `true` to `parent` to search upwards.
  */
-export function useInstance<T = any>(parent: boolean = false): React.MutableRefObject<T | undefined> {
+export function useNearestInstance<T = any>(parent: boolean = false): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()
   const instance = React.useRef<T>()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,14 +89,7 @@ export function useNearestInstance<T = any>(ascending: boolean = false): React.M
   const instance = React.useRef<T>()
 
   React.useLayoutEffect(() => {
-    instance.current = __unsafe_traverse_fiber(
-      fiber,
-      (node) =>
-        node.stateNode != null &&
-        !(node.stateNode instanceof React.Component) &&
-        node.stateNode.containerInfo === undefined,
-      ascending,
-    )?.stateNode
+    instance.current = __unsafe_traverse_fiber(fiber, (node) => typeof node.type === 'string', ascending)?.stateNode
   }, [fiber, ascending])
 
   return instance

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,9 @@ export type Fiber = Reconciler.Fiber
 export type FiberSelector = (node: Fiber) => boolean | void
 
 /**
- * Traverses through a {@link Fiber}, return `true` to halt. `ascending` is true by default.
+ * Traverses through a {@link Fiber}, return `true` to halt. `ascending` is `false` by default.
  */
-export function __unsafe_traverse_fiber(fiber: Fiber, selector: FiberSelector, ascending = true): Fiber | undefined {
+export function __unsafe_traverse_fiber(fiber: Fiber, selector: FiberSelector, ascending = false): Fiber | undefined {
   let halted = false
   let selected: Fiber | undefined
 
@@ -77,6 +77,7 @@ export function useNearestContainer<T = any>(): React.MutableRefObject<Container
     container.current = __unsafe_traverse_fiber(
       fiber,
       (node) => node.stateNode != null && node.stateNode.containerInfo != null,
+      true,
     )?.stateNode
   }, [fiber])
 
@@ -84,9 +85,9 @@ export function useNearestContainer<T = any>(): React.MutableRefObject<Container
 }
 
 /**
- * Returns the nearest {@link Fiber} instance. Pass `true` to `parent` to search upwards.
+ * Returns the nearest {@link Fiber} instance. Pass `true` to `ascending` to search upwards.
  */
-export function useNearestInstance<T = any>(parent: boolean = false): React.MutableRefObject<T | undefined> {
+export function useNearestInstance<T = any>(ascending: boolean = false): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()
   const instance = React.useRef<T>()
 
@@ -97,9 +98,9 @@ export function useNearestInstance<T = any>(parent: boolean = false): React.Muta
         node.stateNode != null &&
         !(node.stateNode instanceof React.Component) &&
         node.stateNode.containerInfo === undefined,
-      parent,
+      ascending,
     )?.stateNode
-  }, [fiber, parent])
+  }, [fiber, ascending])
 
   return instance
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,78 @@
+import * as React from 'react'
+import type Reconciler from 'react-reconciler'
+
+/**
+ * Represents a react-internal Fiber node.
+ */
+export type Fiber = Reconciler.Fiber
+
+/**
+ * Represents a {@link Fiber} node selector for traversal.
+ */
+export type FiberSelector = (node: Fiber) => boolean | void
+
+/**
+ * Traverses through a {@link Fiber}, return `true` to halt. `ascending` is true by default.
+ */
+export function __unsafe_traverse_fiber(fiber: Fiber, selector: FiberSelector, ascending = true): Fiber | undefined {
+  let halted = false
+  let selected: Fiber | undefined
+
+  let node = fiber[ascending ? 'return' : 'child']
+  let sibling = fiber.sibling
+  while (node) {
+    while (sibling) {
+      halted ||= !!selector(sibling)
+      if (halted) {
+        selected = sibling
+        break
+      }
+
+      sibling = sibling.sibling
+    }
+
+    halted ||= !!selector(node)
+    if (halted) {
+      selected = node
+      break
+    }
+
+    node = node[ascending ? 'return' : 'child']
+  }
+
+  return selected
+}
+
+declare module 'react' {
+  namespace __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED {
+    const ReactCurrentOwner: React.RefObject<Fiber>
+  }
+}
+
+/**
+ * Returns the current react-internal {@link Fiber}.
+ */
+export function useFiber(): Fiber {
+  const [fiber] = React.useState<Fiber>(
+    () => React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.ReactCurrentOwner.current!,
+  )
+  return fiber
+}
+
+/**
+ * Returns the nearest {@link Fiber} instance. Pass `true` to `parent` to search upwards.
+ */
+export function useInstance<T = any>(parent: boolean = false): React.MutableRefObject<T | undefined> {
+  const fiber = useFiber()
+  const instance = React.useRef<T>()
+
+  React.useLayoutEffect(() => {
+    instance.current = __unsafe_traverse_fiber(
+      fiber,
+      (node) => node.stateNode != null && !(node.stateNode instanceof React.Component),
+      parent,
+    )?.stateNode
+  }, [fiber, parent])
+
+  return instance
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,23 @@ export function useFiber(): Fiber {
 }
 
 /**
+ * Returns the nearest reconciler container.
+ */
+export function useContainer<T = any>(): React.MutableRefObject<T> {
+  const fiber = useFiber()
+  const container = React.useRef<T>(null!)
+
+  React.useLayoutEffect(() => {
+    container.current = __unsafe_traverse_fiber(
+      fiber,
+      (node) => node.stateNode != null && node.stateNode.containerInfo != null,
+    )!.stateNode
+  }, [fiber])
+
+  return container
+}
+
+/**
  * Returns the nearest {@link Fiber} instance. Pass `true` to `parent` to search upwards.
  */
 export function useInstance<T = any>(parent: boolean = false): React.MutableRefObject<T | undefined> {
@@ -69,7 +86,10 @@ export function useInstance<T = any>(parent: boolean = false): React.MutableRefO
   React.useLayoutEffect(() => {
     instance.current = __unsafe_traverse_fiber(
       fiber,
-      (node) => node.stateNode != null && !(node.stateNode instanceof React.Component),
+      (node) =>
+        node.stateNode != null &&
+        !(node.stateNode instanceof React.Component) &&
+        node.stateNode.containerInfo === undefined,
       parent,
     )?.stateNode
   }, [fiber, parent])

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,11 +60,18 @@ export function useFiber(): Fiber {
 }
 
 /**
+ * Represents a reconciler container.
+ */
+export interface Container<T = {}> {
+  containerInfo: T
+}
+
+/**
  * Returns the nearest reconciler container.
  */
-export function useContainer<T = any>(): React.MutableRefObject<T> {
+export function useContainer<T = any>(): React.MutableRefObject<Container<T>> {
   const fiber = useFiber()
-  const container = React.useRef<T>(null!)
+  const container = React.useRef<Container<T>>(null!)
 
   React.useLayoutEffect(() => {
     container.current = __unsafe_traverse_fiber(

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,14 +60,21 @@ export function useFiber(): Fiber {
 }
 
 /**
- * Returns the current react-reconciler container.
+ * Represents a reconciler container.
  */
-export function useContainer<T = any>(): T {
+export interface Container<T = {}> {
+  containerInfo: T
+}
+
+/**
+ * Returns the current react-reconciler {@link Container}.
+ */
+export function useContainer<T = any>(): Container<T> {
   const fiber = useFiber()
   const container = React.useMemo(
     () =>
       __unsafe_traverse_fiber(fiber, (node) => node.stateNode != null && node.stateNode.containerInfo != null, true)!
-        .stateNode.containerInfo,
+        .stateNode,
     [fiber],
   )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export function useNearestContainer<T = any>(): React.MutableRefObject<Container
 }
 
 /**
- * Returns the nearest {@link Fiber} instance. Pass `true` to `ascending` to search upwards.
+ * Returns the nearest reconciler instance. Pass `true` to `ascending` to search upwards.
  */
 export function useNearestInstance<T = any>(ascending: boolean = false): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,19 +60,16 @@ export function useFiber(): Fiber {
 }
 
 /**
- * Returns the nearest react-reconciler {@link Container}.
+ * Returns the current react-reconciler container.
  */
-export function useNearestContainer<T = any>(): React.MutableRefObject<T | undefined> {
+export function useContainer<T = any>(): T {
   const fiber = useFiber()
-  const container = React.useRef<T>(null!)
-
-  React.useLayoutEffect(() => {
-    container.current = __unsafe_traverse_fiber(
-      fiber,
-      (node) => node.stateNode != null && node.stateNode.containerInfo != null,
-      true,
-    )?.stateNode.containerInfo
-  }, [fiber])
+  const container = React.useMemo(
+    () =>
+      __unsafe_traverse_fiber(fiber, (node) => node.stateNode != null && node.stateNode.containerInfo != null, true)!
+        .stateNode.containerInfo,
+    [fiber],
+  )
 
   return container
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,11 @@ export function useContainer<T = any>(): Container<T> {
   const fiber = useFiber()
   const container = React.useMemo(
     () =>
-      traverseFiber(fiber, (node) => node.stateNode != null && node.stateNode.containerInfo != null, true)!.stateNode,
+      traverseFiber(
+        fiber,
+        (node) => node.type == null && node.stateNode != null && node.stateNode.containerInfo != null,
+        true,
+      )!.stateNode,
     [fiber],
   )
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 import { act, render, type HostContainer, type NilNode } from 'react-nil'
-import { type Fiber, useFiber, useInstance, type Container, useContainer } from '../src'
+import { type Fiber, useFiber, useNearestInstance, type Container, useNearestContainer } from '../src'
 
 interface ReactProps {
   key?: React.Key
@@ -45,27 +45,27 @@ describe('useFiber', () => {
   })
 })
 
-describe('useContainer', () => {
+describe('useNearestContainer', () => {
   it('gets the nearest reconciler container', async () => {
-    let containerRef!: React.MutableRefObject<Container<HostContainer>>
+    let containerRef!: React.MutableRefObject<Container<HostContainer> | undefined>
     let container!: HostContainer
 
     function Test() {
-      containerRef = useContainer()
+      containerRef = useNearestContainer()
       return null
     }
     await act(async () => (container = render(<Test />)))
 
-    expect(containerRef.current.containerInfo).toBe(container)
+    expect(containerRef.current!.containerInfo).toBe(container)
   })
 })
 
-describe('useInstance', () => {
+describe('useNearestInstance', () => {
   it('gets the nearest child instance', async () => {
     const instances: React.MutableRefObject<NilNode<PrimitiveProps> | undefined>[] = []
 
     function Test(props: React.PropsWithChildren) {
-      instances.push(useInstance())
+      instances.push(useNearestInstance())
       return <>{props.children}</>
     }
 
@@ -101,7 +101,7 @@ describe('useInstance', () => {
     const instances: React.MutableRefObject<NilNode<PrimitiveProps> | undefined>[] = []
 
     function Test(props: React.PropsWithChildren) {
-      instances.push(useInstance(true))
+      instances.push(useNearestInstance(true))
       return <>{props.children}</>
     }
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 import { act, render, type HostContainer, type NilNode } from 'react-nil'
-import { type Fiber, useFiber, useInstance, useContainer } from '../src'
+import { type Fiber, useFiber, useInstance, type Container, useContainer } from '../src'
 
 interface ReactProps {
   key?: React.Key
@@ -47,7 +47,7 @@ describe('useFiber', () => {
 
 describe('useContainer', () => {
   it('gets the nearest reconciler container', async () => {
-    let containerRef!: React.MutableRefObject<{ containerInfo: HostContainer }>
+    let containerRef!: React.MutableRefObject<Container<HostContainer>>
     let container!: HostContainer
 
     function Test() {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 import { act, render, type HostContainer, type NilNode } from 'react-nil'
-import { type Fiber, useFiber, useNearestInstance, useNearestContainer } from '../src'
+import { type Fiber, useFiber, useContainer, useNearestInstance } from '../src'
 
 interface ReactProps {
   key?: React.Key
@@ -45,18 +45,18 @@ describe('useFiber', () => {
   })
 })
 
-describe('useNearestContainer', () => {
-  it('gets the nearest reconciler container', async () => {
-    let containerRef!: React.MutableRefObject<HostContainer | undefined>
+describe('useContainer', () => {
+  it('gets the current react-reconciler container', async () => {
+    let currentContainer!: HostContainer | undefined
     let container!: HostContainer
 
     function Test() {
-      containerRef = useNearestContainer()
+      currentContainer = useContainer()
       return null
     }
     await act(async () => (container = render(<Test />)))
 
-    expect(containerRef.current!).toBe(container)
+    expect(currentContainer!).toBe(container)
   })
 })
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 import { act, render, type HostContainer, type NilNode } from 'react-nil'
-import { type Fiber, useFiber, type Container, useContainer, useNearestInstance } from '../src'
+import { type Fiber, useFiber, type Container, useContainer, useNearestChild, useNearestParent } from '../src'
 
 interface ReactProps {
   key?: React.Key
@@ -54,18 +54,25 @@ describe('useContainer', () => {
       currentContainer = useContainer()
       return null
     }
-    await act(async () => (container = render(<Test />)))
+    await act(
+      async () =>
+        (container = render(
+          <>
+            <Test />
+          </>,
+        )),
+    )
 
     expect(currentContainer.containerInfo).toBe(container)
   })
 })
 
-describe('useNearestInstance', () => {
+describe('useNearestChild', () => {
   it('gets the nearest child instance', async () => {
     const instances: React.MutableRefObject<NilNode<PrimitiveProps> | undefined>[] = []
 
     function Test(props: React.PropsWithChildren) {
-      instances.push(useNearestInstance())
+      instances.push(useNearestChild())
       return <>{props.children}</>
     }
 
@@ -96,12 +103,14 @@ describe('useNearestInstance', () => {
 
     expect(instances.map((ref) => ref.current?.props?.name)).toStrictEqual([undefined, 'one', 'two', 'two', 'three'])
   })
+})
 
+describe('useNearestParent', () => {
   it('gets the nearest parent instance', async () => {
     const instances: React.MutableRefObject<NilNode<PrimitiveProps> | undefined>[] = []
 
     function Test(props: React.PropsWithChildren) {
-      instances.push(useNearestInstance(true))
+      instances.push(useNearestParent())
       return <>{props.children}</>
     }
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 import { act, render, type HostContainer, type NilNode } from 'react-nil'
-import { type Fiber, useFiber, useContainer, useNearestInstance } from '../src'
+import { type Fiber, useFiber, type Container, useContainer, useNearestInstance } from '../src'
 
 interface ReactProps {
   key?: React.Key
@@ -47,7 +47,7 @@ describe('useFiber', () => {
 
 describe('useContainer', () => {
   it('gets the current react-reconciler container', async () => {
-    let currentContainer!: HostContainer | undefined
+    let currentContainer!: Container<HostContainer>
     let container!: HostContainer
 
     function Test() {
@@ -56,7 +56,7 @@ describe('useContainer', () => {
     }
     await act(async () => (container = render(<Test />)))
 
-    expect(currentContainer!).toBe(container)
+    expect(currentContainer.containerInfo).toBe(container)
   })
 })
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { describe, expect, it } from 'vitest'
 import { act, render, type HostContainer, type NilNode } from 'react-nil'
-import { type Fiber, useFiber, useNearestInstance, type Container, useNearestContainer } from '../src'
+import { type Fiber, useFiber, useNearestInstance, useNearestContainer } from '../src'
 
 interface ReactProps {
   key?: React.Key
@@ -47,7 +47,7 @@ describe('useFiber', () => {
 
 describe('useNearestContainer', () => {
   it('gets the nearest reconciler container', async () => {
-    let containerRef!: React.MutableRefObject<Container<HostContainer> | undefined>
+    let containerRef!: React.MutableRefObject<HostContainer | undefined>
     let container!: HostContainer
 
     function Test() {
@@ -56,7 +56,7 @@ describe('useNearestContainer', () => {
     }
     await act(async () => (container = render(<Test />)))
 
-    expect(containerRef.current!.containerInfo).toBe(container)
+    expect(containerRef.current!).toBe(container)
   })
 })
 

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,0 +1,15 @@
+import { vi } from 'vitest'
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean
+}
+
+// Let React know that we'll be testing effectful components
+global.IS_REACT_ACT_ENVIRONMENT = true
+
+// Mock scheduler to test React features
+vi.mock('scheduler', () => require('scheduler/unstable_mock'))
+
+// Silence react-dom & react-dom/client mismatch
+const logError = global.console.error.bind(global.console.error)
+global.console.error = (...args: any[]) => !args[0].startsWith('Warning') && logError(...args)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,12 @@
+/// <reference types="vitest" />
 import * as path from 'path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  test: {
+    dir: 'tests',
+    setupFiles: 'tests/setupTests.ts',
+  },
   build: {
     minify: false,
     sourcemap: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     target: 'es2018',
     lib: {
       formats: ['cjs', 'es'],
-      entry: 'src/index.ts',
+      entry: 'src/index.tsx',
       fileName: '[name]',
     },
     rollupOptions: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@ postcss@^8.4.16:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-react-nil@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-nil/-/react-nil-1.0.0.tgz#b345b2a167c38bc2d1fe277bd4d7ab41aa73a12b"
-  integrity sha512-27DU8LxlnXsnLn3HjD7pHDQf8KzA2iYU9d8uIPhgnT7mDBuxHcccgs6ih2eLxKIpDuRVQeDecePcqX8EEaw5SQ==
+react-nil@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-nil/-/react-nil-1.1.0.tgz#0aa5b104f95f96a85c0cce7c2984d1361bcf3126"
+  integrity sha512-udbPXRua1wQ28wlpdRGCAQHt5dgZIA3FmOW04znY+IwsdtMbnFL7wvJGA3qhZqkDTy+LWAeN3/xpMi9KEgbrdg==
   dependencies:
     "@types/react-reconciler" "^0.26.7"
     react-reconciler "^0.27.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@^18.0.0":
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
+  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18.0.17":
   version "18.0.18"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.18.tgz#9f16f33d57bc5d9dca848d12c3572110ff9429ac"
@@ -56,6 +63,11 @@
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+
+acorn@^8.7.1:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 assertion-error@^1.1.0:
   version "1.1.0"
@@ -344,6 +356,11 @@ nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -380,6 +397,11 @@ postcss@^8.4.16:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
 react-nil@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-nil/-/react-nil-1.1.0.tgz#0aa5b104f95f96a85c0cce7c2984d1361bcf3126"
@@ -395,6 +417,23 @@ react-reconciler@^0.27.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.21.0"
+
+react-shallow-renderer@^16.15.0:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-18.2.0.tgz#1dd912bd908ff26da5b9fca4fd1c489b9523d37e"
+  integrity sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==
+  dependencies:
+    react-is "^18.2.0"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.0"
 
 react@^18.2.0:
   version "18.2.0"
@@ -433,10 +472,24 @@ scheduler@^0.21.0:
   dependencies:
     loose-envify "^1.1.0"
 
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
+  dependencies:
+    loose-envify "^1.1.0"
+
 source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
+strip-literal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-0.4.0.tgz#0f90e86daecc1eb23c61c62d25238ffad4524634"
+  integrity sha512-ql/sBDoJOybTKSIOWrrh8kgUEMjXMwRAkZTD0EwiwxQH/6tTPkZvMIEjp0CRlpi6V5FMiJyvxeRkEi1KrGISoA==
+  dependencies:
+    acorn "^8.7.1"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -447,6 +500,11 @@ suspend-react@^0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/suspend-react/-/suspend-react-0.0.8.tgz#b0740c1386b4eb652f17affe4339915ee268bd31"
   integrity sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==
+
+tinybench@^2.1.3:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.1.4.tgz#07121795c6a15fcbdcf02ab0d2ce329b1b6145a3"
+  integrity sha512-NFWIw2Gg7EUPdeE8nL1Dc7AMVlk7sOr2PmSNKVuQrZ0YwTOFoshPQ+hcLrgnhK8dTP3FWMCJaf4N+/hXp6lKPw==
 
 tinypool@^0.2.4:
   version "0.2.4"
@@ -480,10 +538,10 @@ typescript@^4.7.4:
   optionalDependencies:
     fsevents "~2.3.2"
 
-vitest@^0.22.1:
-  version "0.22.1"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.22.1.tgz#3122e6024bf782ee9aca53034017af7adb009c32"
-  integrity sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==
+vitest@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.23.0.tgz#12d031b6ac00aa07aef103e7eb648c8f5efbe78c"
+  integrity sha512-I3ctlfiXYprA2tID1qP+m6pmgmKx3HYfRe66MetGOHKCHLY7hz74ihiwIEtN7LReJgF3U5cM735iYPkn/Go1iQ==
   dependencies:
     "@types/chai" "^4.3.3"
     "@types/chai-subset" "^1.3.3"
@@ -491,6 +549,8 @@ vitest@^0.22.1:
     chai "^4.3.6"
     debug "^4.3.4"
     local-pkg "^0.4.2"
+    strip-literal "^0.4.0"
+    tinybench "^2.1.3"
     tinypool "^0.2.4"
     tinyspy "^1.0.2"
     vite "^2.9.12 || ^3.0.0-0"


### PR DESCRIPTION
Initial implementation with base react-internal methods for Fiber and container manipulation.

### useFiber

Returns the current react-internal `Fiber`.

```tsx
function Component() {
  const fiber = useFiber()

  React.useLayoutEffect(() => {
    console.log(fiber.type) // function Component
  }, [fiber])
}
```

### useContainer

Returns the current react-reconciler `Container`.

```tsx
function Component() {
  const container = useContainer()

  React.useLayoutEffect(() => {
    console.log(container.containerInfo.getState()) // Zustand store (e.g. R3F)
  }, [container])
}
```

### useNearestChild

Returns the nearest react-reconciler child instance.

```tsx
function Component() {
  const childRef = useNearestChild()

  React.useLayoutEffect(() => {
    console.log(childRef.current) // { type: 'primitive', props: {}, children: [] } (e.g. react-nil)
  }, [])

  return <primitive />
}
```

### useNearestParent

Returns the nearest react-reconciler parent instance.

```tsx
function Component() {
  const parentRef = useNearestParent()

  React.useLayoutEffect(() => {
    console.log(parentRef.current) // { type: 'primitive', props: {}, children: [] } (e.g. react-nil)
  }, [])

  return null
}

export default () => (
  <primitive>
    <Component />
  </primitive>
)
```

### useContextBridge

Returns a `ContextBridge` of live context providers to pierce context across renderers.

```tsx
function Canvas(props: { children: React.ReactNode }) {
  const Bridge = useContextBridge()
  render(<Bridge>{props.children}</Bridge>)
  return null
}

ReactDOM.createRoot(window.root).render(
  <Providers>
    <Canvas />
  </Providers>
)
```

### traverseFiber

Traverses through a `Fiber`, return `true` to halt.

```ts
const ascending = true
const prevElement = traverseFiber(fiber, ascending, (node) => node.type === 'element')
```
