### PR TITLE
refactor!: only halt traverseFiber on boolean, harden Fiber types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ function Component() {
 
 ### useContainer
 
-Returns the current react-reconciler `Container` or the Fiber created from `Reconciler.createContainer`.
+Returns the current react-reconciler container info passed to `Reconciler.createContainer`.
 
-In react-dom, `container.containerInfo` will point to the root DOM element; in react-three-fiber, it will point to the root Zustand store.
+In react-dom, a container will point to the root DOM element; in react-three-fiber, it will point to the root Zustand store.
 
 ```tsx
 import * as React from 'react'
@@ -73,7 +73,7 @@ function Component() {
 
   React.useLayoutEffect(() => {
     // <div> (e.g. react-dom)
-    console.log(container.containerInfo)
+    console.log(container)
   }, [container])
 }
 ```
@@ -166,5 +166,10 @@ Traverses up or down through a `Fiber`, return `true` to stop and select a node.
 import { type Fiber, traverseFiber } from 'its-fine'
 
 const ascending = true
-const prevElement: Fiber = traverseFiber(fiber, ascending, (node: Fiber) => node.type === 'element')
+
+const parentDiv: Fiber<HTMLDivElement> | undefined = traverseFiber<HTMLDivElement>(
+  fiber as Fiber<null>,
+  ascending,
+  (node: Fiber<HTMLDivElement | null>) => node.type === 'div',
+)
 ```

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,7 +82,7 @@ export function useContainer<T = any>(): T {
       traverseFiber<ContainerInstance<T>>(
         fiber,
         true,
-        (node) => node.type == null && node.stateNode!.containerInfo != null,
+        (node) => node.type == null && node.stateNode?.containerInfo != null,
       )!.stateNode.containerInfo,
     [fiber],
   )

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -132,7 +132,19 @@ describe('traverseFiber', () => {
     expect(rootContainer.stateNode.containerInfo).toBe(container)
   })
 
-  it('returns the active node when halted', async () => {})
+  it('returns the active node when halted', async () => {
+    let fiber!: Fiber
+    let container!: HostContainer
+
+    function Test() {
+      fiber = useFiber()
+      return <primitive name="child" />
+    }
+    await act(async () => (container = render(<Test />)))
+
+    const child = traverseFiber<Primitive>(fiber, false, (node) => node.stateNode === container.head)
+    expect(child!.stateNode.props.name).toBe('child')
+  })
 })
 
 describe('useContainer', () => {


### PR DESCRIPTION
This PR ensures that `traverseFiber` will only halt when `true` is passed to a selector. This forces selectors to return a boolean and will continue as an effect in any other case, including if a method returns a truthy value.

Additionally, Fiber types are hardened to show interoperability, and `useContainer` now returns `Container.containerInfo` by default. As a result, the `Container` type is removed. A new type `ContainerInstance` represents the internal container instance.