### PR TITLE
feat: optionally filter by type in useNearest*

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ import * as React from 'react'
 import { useNearestChild } from 'its-fine'
 
 function Component() {
-  // Returns a React Ref which points to the nearest child element
-  const childRef: React.MutableRefObject<HTMLDivElement | undefined> = useNearestChild<HTMLDivElement>()
+  // Returns a React Ref which points to the nearest child <div /> element.
+  // Omit the element type to match the nearest element of any kind
+  const childRef: React.MutableRefObject<HTMLDivElement | undefined> = useNearestChild<HTMLDivElement>('div')
 
   // Access child Ref on mount
   React.useEffect(() => {
@@ -101,8 +102,9 @@ import * as React from 'react'
 import { useNearestParent } from 'its-fine'
 
 function Component() {
-  // Returns a React Ref which points to the nearest parent element
-  const parentRef: React.MutableRefObject<HTMLDivElement | undefined> = useNearestParent<HTMLDivElement>()
+  // Returns a React Ref which points to the nearest parent <div /> element.
+  // Omit the element type to match the nearest element of any kind
+  const parentRef: React.MutableRefObject<HTMLDivElement | undefined> = useNearestParent<HTMLDivElement>('div')
 
   // Access parent Ref on mount
   React.useEffect(() => {
@@ -180,7 +182,7 @@ const parentDiv: Fiber<HTMLDivElement> | undefined = traverseFiber<HTMLDivElemen
   fiber as Fiber,
   // Whether to ascend and walk up the tree. Will walk down if `false`
   true,
-  // A Fiber node selector, returns the first <div /> element in JSX
+  // A Fiber node selector, returns the first match when `true` is passed
   (node: Fiber<HTMLDivElement | null>) => node.type === 'div',
 )
 ```

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,7 +81,7 @@ export function useContainer<T = any>(): T {
  */
 export function useNearestChild<T = any>(
   /** An optional element type to filter to. */
-  type?: string,
+  type?: keyof JSX.IntrinsicElements,
 ): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()
   const childRef = React.useRef<T>()
@@ -104,7 +104,7 @@ export function useNearestChild<T = any>(
  */
 export function useNearestParent<T = any>(
   /** An optional element type to filter to. */
-  type?: string,
+  type?: keyof JSX.IntrinsicElements,
 ): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()
   const parentRef = React.useRef<T>()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,14 +9,20 @@ export type Fiber<T = any> = Omit<ReactReconciler.Fiber, 'stateNode'> & { stateN
 /**
  * Represents a {@link Fiber} node selector for traversal.
  */
-export type FiberSelector<T = any> = (node: Fiber<T | null>) => boolean | void
+export type FiberSelector<T = any> = (
+  /** The current {@link Fiber} node. */
+  node: Fiber<T | null>,
+) => boolean | void
 
 /**
  * Traverses up or down a {@link Fiber}, return `true` to stop and select a node.
  */
 export function traverseFiber<T = any>(
+  /** Input Fiber to traverse. */
   fiber: Fiber,
+  /** Whether to ascend and walk up the tree. Will walk down if `false`. */
   ascending: boolean,
+  /** A Fiber node selector, returns the first match when `true` is passed */
   selector: FiberSelector<T>,
 ): Fiber<T> | undefined {
   if (selector(fiber) === true) return fiber
@@ -73,12 +79,17 @@ export function useContainer<T = any>(): T {
  *
  * In react-dom, this would be a DOM element; in react-three-fiber this would be an instance descriptor.
  */
-export function useNearestChild<T = any>(): React.MutableRefObject<T | undefined> {
+export function useNearestChild<T = any>(
+  /** An optional element type to filter to. */
+  type?: string,
+): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()
   const childRef = React.useRef<T>()
 
   React.useLayoutEffect(() => {
-    childRef.current = traverseFiber<T>(fiber, false, (node) => typeof node.type === 'string')?.stateNode
+    childRef.current = traverseFiber<T>(fiber, false, (node) =>
+      type ? node.type === type : typeof node.type === 'string',
+    )?.stateNode
   }, [fiber])
 
   return childRef
@@ -89,12 +100,17 @@ export function useNearestChild<T = any>(): React.MutableRefObject<T | undefined
  *
  * In react-dom, this would be a DOM element; in react-three-fiber this would be an instance descriptor.
  */
-export function useNearestParent<T = any>(): React.MutableRefObject<T | undefined> {
+export function useNearestParent<T = any>(
+  /** An optional element type to filter to. */
+  type?: string,
+): React.MutableRefObject<T | undefined> {
   const fiber = useFiber()
   const parentRef = React.useRef<T>()
 
   React.useLayoutEffect(() => {
-    parentRef.current = traverseFiber<T>(fiber, true, (node) => typeof node.type === 'string')?.stateNode
+    parentRef.current = traverseFiber<T>(fiber, true, (node) =>
+      type ? node.type === type : typeof node.type === 'string',
+    )?.stateNode
   }, [fiber])
 
   return parentRef

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,8 +87,10 @@ export function useNearestChild<T = any>(
   const childRef = React.useRef<T>()
 
   React.useLayoutEffect(() => {
-    childRef.current = traverseFiber<T>(fiber, false, (node) =>
-      type ? node.type === type : typeof node.type === 'string',
+    childRef.current = traverseFiber<T>(
+      fiber,
+      false,
+      (node) => typeof node.type === 'string' && (type === undefined || node.type === type),
     )?.stateNode
   }, [fiber])
 
@@ -108,8 +110,10 @@ export function useNearestParent<T = any>(
   const parentRef = React.useRef<T>()
 
   React.useLayoutEffect(() => {
-    parentRef.current = traverseFiber<T>(fiber, true, (node) =>
-      type ? node.type === type : typeof node.type === 'string',
+    parentRef.current = traverseFiber<T>(
+      fiber,
+      true,
+      (node) => typeof node.type === 'string' && (type === undefined || node.type === type),
     )?.stateNode
   }, [fiber])
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -170,8 +170,8 @@ describe('useNearestChild', () => {
   it('gets the nearest child instance', async () => {
     const instances: React.MutableRefObject<Primitive | undefined>[] = []
 
-    function Test(props: React.PropsWithChildren<{ type?: string }>) {
-      instances.push(useNearestChild<Primitive>(props.type))
+    function Test(props: React.PropsWithChildren<{ strict?: boolean }>) {
+      instances.push(useNearestChild<Primitive>(props.strict ? 'element' : undefined))
       return <>{props.children}</>
     }
 
@@ -192,7 +192,7 @@ describe('useNearestChild', () => {
               <primitive name="two" />
             </ClassComponent>
           </Test>
-          <Test type="element">
+          <Test strict>
             <primitive name="three" />
             <element name="four" />
           </Test>
@@ -208,8 +208,8 @@ describe('useNearestParent', () => {
   it('gets the nearest parent instance', async () => {
     const instances: React.MutableRefObject<Primitive | undefined>[] = []
 
-    function Test(props: React.PropsWithChildren<{ type?: string }>) {
-      instances.push(useNearestParent<Primitive>(props.type))
+    function Test(props: React.PropsWithChildren<{ strict?: boolean }>) {
+      instances.push(useNearestParent<Primitive>(props.strict ? 'element' : undefined))
       return <>{props.children}</>
     }
 
@@ -231,7 +231,7 @@ describe('useNearestParent', () => {
               </primitive>
               <element name="four">
                 <primitive name="three">
-                  <Test type="element" />
+                  <Test strict />
                 </primitive>
               </element>
             </>

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -29,6 +29,7 @@ declare global {
   namespace JSX {
     interface IntrinsicElements {
       primitive: ReactProps & PrimitiveProps
+      element: ReactProps & PrimitiveProps
     }
   }
 }
@@ -169,8 +170,8 @@ describe('useNearestChild', () => {
   it('gets the nearest child instance', async () => {
     const instances: React.MutableRefObject<Primitive | undefined>[] = []
 
-    function Test(props: React.PropsWithChildren) {
-      instances.push(useNearestChild<Primitive>())
+    function Test(props: React.PropsWithChildren<{ type?: string }>) {
+      instances.push(useNearestChild<Primitive>(props.type))
       return <>{props.children}</>
     }
 
@@ -191,15 +192,15 @@ describe('useNearestChild', () => {
               <primitive name="two" />
             </ClassComponent>
           </Test>
-          <Test>
+          <Test type="element">
             <primitive name="three" />
-            <primitive name="four" />
+            <element name="four" />
           </Test>
         </>,
       )
     })
 
-    expect(instances.map((ref) => ref.current?.props?.name)).toStrictEqual([undefined, 'one', 'two', 'two', 'three'])
+    expect(instances.map((ref) => ref.current?.props?.name)).toStrictEqual([undefined, 'one', 'two', 'two', 'four'])
   })
 })
 
@@ -207,8 +208,8 @@ describe('useNearestParent', () => {
   it('gets the nearest parent instance', async () => {
     const instances: React.MutableRefObject<Primitive | undefined>[] = []
 
-    function Test(props: React.PropsWithChildren) {
-      instances.push(useNearestParent<Primitive>())
+    function Test(props: React.PropsWithChildren<{ type?: string }>) {
+      instances.push(useNearestParent<Primitive>(props.type))
       return <>{props.children}</>
     }
 
@@ -228,13 +229,25 @@ describe('useNearestParent', () => {
               <primitive name="two">
                 <Test />
               </primitive>
+              <element name="four">
+                <primitive name="three">
+                  <Test type="element" />
+                </primitive>
+              </element>
             </>
           </primitive>
         </>,
       )
     })
 
-    expect(instances.map((ref) => ref.current?.props?.name)).toStrictEqual([undefined, 'one', 'one', 'one', 'two'])
+    expect(instances.map((ref) => ref.current?.props?.name)).toStrictEqual([
+      undefined,
+      'one',
+      'one',
+      'one',
+      'two',
+      'four',
+    ])
   })
 })
 


### PR DESCRIPTION
Adds an optional `type` arg to filter `useNearestParent` and `useNearestChild` to the nearest element of a type.

```tsx
// react-three-fiber
const meshRef = useNearestParent('mesh')
// react-dom
const svgRef = useNearestChild('svg')
```