### PR TITLE
feat!: FiberProvider for stable reference in useFiber

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ As such, you can go beyond React's component abstraction; components are self-aw
 
 ## Table of Contents
 
+- [Components](#components)
+  - [FiberProvider](#fiberprovider)
 - [Hooks](#hooks)
   - [useFiber](#useFiber)
   - [useContainer](#useContainer)

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ import { type Fiber, useFiber } from 'its-fine'
 
 function Component() {
   // Returns the current component's react-internal Fiber
-  const fiber: Fiber<null> = useFiber()
+  const fiber: Fiber<null> | undefined = useFiber()
 
   // function Component() {}
-  console.log(fiber.type)
+  if (fiber) console.log(fiber.type)
 }
 ```
 
@@ -84,10 +84,10 @@ import { useContainer } from 'its-fine'
 
 function Component() {
   // Returns the current renderer's root container
-  const container: HTMLDivElement = useContainer<HTMLDivElement>()
+  const container: HTMLDivElement | undefined = useContainer<HTMLDivElement>()
 
   // <div> (e.g. react-dom)
-  console.log(container)
+  if (container) console.log(container)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,32 @@ As such, you can go beyond React's component abstraction; components are self-aw
 - [Utils](#utils)
   - [traverseFiber](#traverseFiber)
 
+## Components
+
+### FiberProvider
+
+A react-internal `Fiber` provider. This component binds React children to the React Fiber tree. Call its-fine hooks within this.
+
+> **Note**: pmndrs renderers like react-three-fiber implement this internally to make use of [`useContextBridge`](#usecontextbridge), so you would only need this when using hooks inside of `react-dom` or `react-native`.
+
+```tsx
+import * as ReactDOM from 'react-dom/client'
+import { FiberProvider } from 'its-fine'
+
+function App() {
+  const fiber = useFiber()
+}
+
+createRoot(document.getElementById('root')!).render(
+  <FiberProvider>
+    <App />
+  </FiberProvider>,
+)
+```
+
 ## Hooks
 
-Useful React hook abstractions for manipulating and querying from a component.
+Useful React hook abstractions for manipulating and querying from a component. These must be called within a [`FiberProvider`](#fiberprovider) component.
 
 ### useFiber
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,12 +19,13 @@ export type FiberSelector<T = any> = (
  */
 export function traverseFiber<T = any>(
   /** Input {@link Fiber} to traverse. */
-  fiber: Fiber,
+  fiber: Fiber | undefined,
   /** Whether to ascend and walk up the tree. Will walk down if `false`. */
   ascending: boolean,
   /** A {@link Fiber} node selector, returns the first match when `true` is passed. */
   selector: FiberSelector<T>,
 ): Fiber<T> | undefined {
+  if (!fiber) return
   if (selector(fiber) === true) return fiber
 
   let child = ascending ? fiber.return : fiber.child
@@ -82,7 +83,7 @@ const { ReactCurrentOwner, ReactCurrentDispatcher } = (React as unknown as React
 /**
  * Returns the current react-internal {@link Fiber}. This is an implementation detail of [react-reconciler](https://github.com/facebook/react/tree/main/packages/react-reconciler).
  */
-export function useFiber(): Fiber<null> {
+export function useFiber(): Fiber<null> | undefined {
   const root = React.useContext(FiberContext)
   if (!root) throw new Error('its-fine: useFiber must be called within a <FiberProvider />!')
 
@@ -102,7 +103,7 @@ export function useFiber(): Fiber<null> {
     [root, id],
   )
 
-  return fiber!
+  return fiber
 }
 
 /**
@@ -117,14 +118,14 @@ export interface ContainerInstance<T = any> {
  *
  * In react-dom, a container will point to the root DOM element; in react-three-fiber, it will point to the root Zustand store.
  */
-export function useContainer<T = any>(): T {
+export function useContainer<T = any>(): T | undefined {
   const fiber = useFiber()
   const root = React.useMemo(
     () => traverseFiber<ContainerInstance<T>>(fiber, true, (node) => node.stateNode?.containerInfo != null),
     [fiber],
   )
 
-  return root!.stateNode.containerInfo
+  return root?.stateNode.containerInfo
 }
 
 /**

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -11,6 +11,7 @@ import {
   useNearestChild,
   useNearestParent,
   useContextBridge,
+  FiberProvider,
 } from '../src'
 
 interface ReactProps {
@@ -42,6 +43,14 @@ class ClassComponent extends React.Component<{ children?: React.ReactNode }> {
 }
 
 describe('useFiber', () => {
+  it('throws when used outside of a FiberProvider', async () => {
+    function Test() {
+      useFiber()
+      return null
+    }
+    expect(() => render(<Test />)).toThrow()
+  })
+
   it('gets the current react-internal Fiber', async () => {
     let fiber!: Fiber
 
@@ -49,7 +58,13 @@ describe('useFiber', () => {
       fiber = useFiber()
       return <primitive />
     }
-    const container = await act(async () => render(<Test />))
+    const container = await act(async () =>
+      render(
+        <FiberProvider>
+          <Test />
+        </FiberProvider>,
+      ),
+    )
 
     expect(fiber).toBeDefined()
     expect(fiber.type).toBe(Test)
@@ -65,11 +80,21 @@ describe('useFiber', () => {
     }
 
     function Wrapper() {
-      render(<Test />)
+      render(
+        <FiberProvider>
+          <Test />
+        </FiberProvider>,
+      )
       return <Test />
     }
 
-    await act(async () => create(<Wrapper />))
+    await act(async () =>
+      create(
+        <FiberProvider>
+          <Wrapper />
+        </FiberProvider>,
+      ),
+    )
 
     const [outer, inner] = fibers
     expect(outer).not.toBe(inner)
@@ -88,9 +113,11 @@ describe('traverseFiber', () => {
     }
     await act(async () =>
       render(
-        <primitive name="parent">
-          <Test />
-        </primitive>,
+        <FiberProvider>
+          <primitive name="parent">
+            <Test />
+          </primitive>
+        </FiberProvider>,
       ),
     )
 
@@ -113,9 +140,11 @@ describe('traverseFiber', () => {
     }
     const container = await act(async () =>
       render(
-        <primitive name="parent">
-          <Test />
-        </primitive>,
+        <FiberProvider>
+          <primitive name="parent">
+            <Test />
+          </primitive>
+        </FiberProvider>,
       ),
     )
 
@@ -141,7 +170,13 @@ describe('traverseFiber', () => {
       fiber = useFiber()
       return <primitive name="child" />
     }
-    const container = await act(async () => render(<Test />))
+    const container = await act(async () =>
+      render(
+        <FiberProvider>
+          <Test />
+        </FiberProvider>,
+      ),
+    )
 
     const child = traverseFiber<Primitive>(fiber, false, (node) => node.stateNode === container.head)
     expect(child!.stateNode.props.name).toBe('child')
@@ -157,11 +192,17 @@ describe('useContainer', () => {
       return null
     }
 
-    const rootContainer = await act(async () => render(<Test />))
+    const rootContainer = await act(async () =>
+      render(
+        <FiberProvider>
+          <Test />
+        </FiberProvider>,
+      ),
+    )
     expect(container).toBe(rootContainer)
 
     const portalContainer: HostContainer = { head: null }
-    await act(async () => render(createPortal(<Test />, portalContainer)))
+    await act(async () => render(<FiberProvider>{createPortal(<Test />, portalContainer)}</FiberProvider>))
     expect(container).toBe(portalContainer)
   })
 })
@@ -177,7 +218,7 @@ describe('useNearestChild', () => {
 
     await act(async () => {
       render(
-        <>
+        <FiberProvider>
           <Test />
           <Test>
             <primitive name="one" />
@@ -196,7 +237,7 @@ describe('useNearestChild', () => {
             <primitive name="three" />
             <element name="four" />
           </Test>
-        </>,
+        </FiberProvider>,
       )
     })
 
@@ -215,7 +256,7 @@ describe('useNearestParent', () => {
 
     await act(async () => {
       render(
-        <>
+        <FiberProvider>
           <Test />
           <primitive name="one">
             <>
@@ -236,7 +277,7 @@ describe('useNearestParent', () => {
               </element>
             </>
           </primitive>
-        </>,
+        </FiberProvider>,
       )
     })
 
@@ -260,7 +301,8 @@ describe('useContextBridge', () => {
     const inner: string[] = []
 
     function Test({ secondary }: { secondary?: boolean }) {
-      ;(secondary ? inner : outer).push(React.useContext(Context1), React.useContext(Context2))
+      const target = secondary ? inner : outer
+      target.push(React.useContext(Context1), React.useContext(Context2))
 
       return null
     }
@@ -284,11 +326,13 @@ describe('useContextBridge', () => {
     function Providers(props: { values: [value1: string, value2: string]; children: React.ReactNode }) {
       const [value1, value2] = props.values
       return (
-        <Context1.Provider value="invalid">
-          <Context1.Provider value={value1}>
-            <Context2.Provider value={value2}>{props.children}</Context2.Provider>
+        <FiberProvider>
+          <Context1.Provider value="invalid">
+            <Context1.Provider value={value1}>
+              <Context2.Provider value={value2}>{props.children}</Context2.Provider>
+            </Context1.Provider>
           </Context1.Provider>
-        </Context1.Provider>
+        </FiberProvider>
       )
     }
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -62,7 +62,7 @@ describe('useFiber', () => {
     let fiber!: Fiber
 
     function Test() {
-      fiber = useFiber()
+      fiber = useFiber()!
       return <primitive />
     }
     const container = await act(async () =>
@@ -82,7 +82,7 @@ describe('useFiber', () => {
     const fibers: Fiber[] = []
 
     function Test() {
-      fibers.push(useFiber())
+      fibers.push(useFiber()!)
       return null
     }
 
@@ -115,7 +115,7 @@ describe('traverseFiber', () => {
     let fiber!: Fiber
 
     function Test() {
-      fiber = useFiber()
+      fiber = useFiber()!
       return <primitive name="child" />
     }
     await act(async () =>
@@ -142,7 +142,7 @@ describe('traverseFiber', () => {
     let fiber!: Fiber
 
     function Test() {
-      fiber = useFiber()
+      fiber = useFiber()!
       return <primitive name="child" />
     }
     const container = await act(async () =>
@@ -167,7 +167,7 @@ describe('traverseFiber', () => {
     let fiber!: Fiber
 
     function Test() {
-      fiber = useFiber()
+      fiber = useFiber()!
       return <primitive name="child" />
     }
     const container = await act(async () =>
@@ -188,7 +188,7 @@ describe('useContainer', () => {
     let container!: HostContainer
 
     function Test() {
-      container = useContainer<HostContainer>()
+      container = useContainer<HostContainer>()!
       return null
     }
 


### PR DESCRIPTION
Implements a `<FiberProvider />` component that binds calls to `useFiber` to the React Fiber tree. This ensures that components get a stable reference to their respective Fiber regardless of their environment.

> **Note**: pmndrs renderers like react-three-fiber implement this internally to make use of [`useContextBridge`](#usecontextbridge), so you would only need this when using hooks inside of `react-dom` or `react-native`.

```tsx
import * as ReactDOM from 'react-dom/client'
import { FiberProvider } from 'its-fine'

function App() {
  const fiber = useFiber()
}

createRoot(document.getElementById('root')!).render(
  <FiberProvider>
    <App />
  </FiberProvider>,
)
```