### PR TITLE
fix: invalidate context on suspense

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -192,9 +192,10 @@ export function useContextBridge(): ContextBridge {
   const fiber = useFiber()
 
   // Collect live context
+  contexts.splice(0, contexts.length)
   traverseFiber(fiber, true, (node) => {
     const context = node.type?._context
-    if (context && context !== FiberContext && !contexts.includes(context)) contexts.push(wrapContext(context))
+    if (context && context !== FiberContext) contexts.push(wrapContext(context))
   })
 
   // Update memoized values


### PR DESCRIPTION
Invalidates live context to play nice with cross-renderer suspense bubbling employed by R3F that would suspend parent providers.