### PR TITLE
fix: prefer js ext for module target

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,14 @@
     "dist/*",
     "src/*"
   ],
+  "type": "module",
   "types": "./dist/index.d.ts",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
     "types": "./dist/index.d.ts",
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs"
+    "require": "./dist/index.cjs",
+    "import": "./dist/index.js"
   },
   "sideEffects": false,
   "devDependencies": {


### PR DESCRIPTION
Tries to work around a CRA/Webpack issue with Node ESM from #12, https://github.com/facebook/create-react-app/issues/10356.