### PR TITLE
fix: alias react-native entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
+  "react-native": "./dist/index.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "require": "./dist/index.cjs",


### PR DESCRIPTION
Eases configuration from #16 since Metro doesn't understand Node-specific file extensions OOTB.