### PR TITLE
chore: optimize context traversal

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -183,6 +183,8 @@ export function useNearestParent<T = any>(
  */
 export type ContextBridge = React.FC<React.PropsWithChildren<{}>>
 
+const contexts: React.Context<any>[] = []
+
 /**
  * React Context currently cannot be shared across [React renderers](https://reactjs.org/docs/codebase-overview.html#renderers) but explicitly forwarded between providers (see [react#17275](https://github.com/facebook/react/issues/17275)). This hook returns a {@link ContextBridge} of live context providers to pierce Context across renderers.
  *
@@ -190,10 +192,7 @@ export type ContextBridge = React.FC<React.PropsWithChildren<{}>>
  */
 export function useContextBridge(): ContextBridge {
   const fiber = useFiber()
-
-  // Live context and their memoized values
-  const contexts: React.Context<any>[] = React.useMemo(() => [], [])
-  const values = React.useMemo(() => new WeakMap<React.Context<any>, any>(), [])
+  const [values] = React.useState(() => new WeakMap<React.Context<any>, any>())
 
   // Collect live context
   contexts.splice(0, contexts.length)


### PR DESCRIPTION
Only traverses to direct parents for context retrieval and makes better use of mapped memory for the bridge.