### PR TITLE
fix: throw when useFiber is used without a FiberProvider

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,16 +81,15 @@ interface ReactInternal {
   }
 }
 
-const { ReactCurrentOwner, ReactCurrentDispatcher } =
-  (React as unknown as ReactInternal).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED ?? {}
+const { ReactCurrentOwner, ReactCurrentDispatcher } = (React as unknown as ReactInternal)
+  .__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED
 
 /**
  * Returns the current react-internal {@link Fiber}. This is an implementation detail of [react-reconciler](https://github.com/facebook/react/tree/main/packages/react-reconciler).
  */
 export function useFiber(): Fiber<null> | undefined {
   const root = React.useContext(FiberContext)
-
-  if (!root) throw new Error('No FiberProvider found. Call useFiber() within a FiberProvider.')
+  if (root === null) throw new Error('its-fine: useFiber must be called within a <FiberProvider />!')
 
   // In development mode, React will expose the current component's Fiber as ReactCurrentOwner.
   // In production, we don't have this luxury and must traverse from FiberProvider via useId

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -90,6 +90,8 @@ const { ReactCurrentOwner, ReactCurrentDispatcher } =
 export function useFiber(): Fiber<null> | undefined {
   const root = React.useContext(FiberContext)
 
+  if (!root) throw new Error('No FiberProvider found. Call useFiber() within a FiberProvider.')
+
   // In development mode, React will expose the current component's Fiber as ReactCurrentOwner.
   // In production, we don't have this luxury and must traverse from FiberProvider via useId
   const id = React.useId()

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -158,13 +158,13 @@ describe('traverseFiber', () => {
       ),
     )
 
-    const traversed: Fiber<any>[] = [];
+    const traversed: Fiber<any>[] = []
     traverseFiber(fiber, true, (node) => void traversed.push(node))
 
-    expect(traversed.filter(o => o.stateNode?.props?.name === "other").length).toBe(0)
-    expect(traversed.filter(o => o.stateNode?.props?.name === "ancestor").length).toBe(1)
-    expect(traversed.filter(o => o.stateNode?.props?.name === "parent").length).toBe(1)
-    
+    expect(traversed.filter((o) => o.stateNode?.props?.name === 'other').length).toBe(0)
+    expect(traversed.filter((o) => o.stateNode?.props?.name === 'ancestor').length).toBe(1)
+    expect(traversed.filter((o) => o.stateNode?.props?.name === 'parent').length).toBe(1)
+
     const [self, parent, ancestor] = traversed
     expect(self.type).toBe(Test)
     expect(parent.stateNode?.props?.name).toBe('parent')

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -42,7 +42,7 @@ class ClassComponent extends React.Component<{ children?: React.ReactNode }> {
 }
 
 describe('useFiber', () => {
-  it('silently fails when used outside of a FiberProvider', async () => {
+  it('throws when used outside of a FiberProvider', async () => {
     let threw = false
 
     function Test() {
@@ -55,7 +55,7 @@ describe('useFiber', () => {
     }
     await act(async () => render(<Test />))
 
-    expect(threw).toBe(false)
+    expect(threw).toBe(true)
   })
 
   it('gets the current react-internal Fiber', async () => {
@@ -158,13 +158,13 @@ describe('traverseFiber', () => {
       ),
     )
 
-    const traversed: Fiber<any>[] = []
+    const traversed: Fiber<any>[] = [];
     traverseFiber(fiber, true, (node) => void traversed.push(node))
 
-    expect(traversed.filter((o) => o.stateNode?.props?.name === 'other').length).toBe(0)
-    expect(traversed.filter((o) => o.stateNode?.props?.name === 'ancestor').length).toBe(1)
-    expect(traversed.filter((o) => o.stateNode?.props?.name === 'parent').length).toBe(1)
-
+    expect(traversed.filter(o => o.stateNode?.props?.name === "other").length).toBe(0)
+    expect(traversed.filter(o => o.stateNode?.props?.name === "ancestor").length).toBe(1)
+    expect(traversed.filter(o => o.stateNode?.props?.name === "parent").length).toBe(1)
+    
     const [self, parent, ancestor] = traversed
     expect(self.type).toBe(Test)
     expect(parent.stateNode?.props?.name).toBe('parent')


### PR DESCRIPTION
I spent some time debugging why my app (which uses `useContextBridge`) wasn't working in production, the reason was I didn't have a FiberProvider. This might be a breaking change so I can of course change it, but would it be possible to add some kind of error or warning when there's no FiberContext? Is there any reason it should not throw?