### PR TITLE
feat: expose useContextMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ As such, you can go beyond React's component abstraction; components are self-aw
   - [useContainer](#useContainer)
   - [useNearestChild](#useNearestChild)
   - [useNearestParent](#useNearestParent)
+  - [useContextMap](#useContextMap)
   - [useContextBridge](#useContextBridge)
 - [Utils](#utils)
   - [traverseFiber](#traverseFiber)
@@ -146,6 +147,23 @@ function Component() {
 ;<div>
   <Component />
 </div>
+```
+
+### useContextMap
+
+Returns a map of all contexts and their values.
+
+```tsx
+import * as React from 'react'
+import { useContextMap } from 'its-fine'
+
+const SomeContext = React.createContext<string>(null!)
+
+function Component() {
+  const contextMap = useContextMap()
+
+  return contextMap.get(SomeContext)
+}
 ```
 
 ### useContextBridge


### PR DESCRIPTION
Exposes `useAllContexts`.

This would be useful for me in [@bubblydoo/angular-react](https://github.com/bubblydoo/angular-react#reading-react-contexts-in-angular), as I can use this function to inject React contexts into Angular.

See [the usage of useAllContexts](https://github.com/bubblydoo/angular-react/blob/main/projects/angular-react/src/lib/passed-react-context-token/use-create-passed-react-context.ts) (I've temporarily forked its-fine) and [an example of an Angular component using it](https://github.com/bubblydoo/angular-react/blob/main/stories/injected-contexts.stories.tsx) and [the deployed example](http://localhost:6006/?path=/story/basics-injected-contexts--showcase).